### PR TITLE
[Fix] Replace `safe_load` with `load` for YAML class

### DIFF
--- a/app/lib/rails_i18n_manager/forms/translation_file_form.rb
+++ b/app/lib/rails_i18n_manager/forms/translation_file_form.rb
@@ -35,7 +35,7 @@ module RailsI18nManager
 
         case File.extname(file)
         when ".yml"
-          if !YAML.safe_load(File.read(file)).is_a?(Hash)
+          if !YAML.load(File.read(file)).is_a?(Hash)
             errors.add(:file, "Invalid yml file.")
             return
           end


### PR DESCRIPTION
# Description 

Replaced the usage of safe_load with load in TranslationFileForm#validate_file to align with the updated capabilities of safe_load that now allow symbols.

Check soure code: https://github.com/rails/rails/blob/c3b396cacb32d4bf48b81bfee52b70800a182c80/activerecord/lib/active_record/coders/yaml_column.rb#L37C30-L37C30